### PR TITLE
fix(rxjs-state): 🐞 build library in Angular Package Format for more generic support (fixes #3)

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -105,6 +105,18 @@
       "projectType": "library",
       "schematics": {},
       "architect": {
+        "build": {
+          "builder": "@nrwl/angular:package",
+          "options": {
+            "tsConfig": "libs/rxjs-state/tsconfig.lib.json",
+            "project": "libs/rxjs-state/ng-package.json"
+          },
+          "configurations": {
+            "production": {
+              "tsConfig": "libs/rxjs-state/tsconfig.lib.prod.json"
+            }
+          }
+        },
         "lint": {
           "builder": "@angular-devkit/build-angular:tslint",
           "options": {
@@ -121,16 +133,6 @@
             "jestConfig": "libs/rxjs-state/jest.config.js",
             "tsConfig": "libs/rxjs-state/tsconfig.spec.json",
             "passWithNoTests": true
-          }
-        },
-        "build": {
-          "builder": "@nrwl/node:package",
-          "options": {
-            "outputPath": "dist/libs/rxjs-state",
-            "tsConfig": "libs/rxjs-state/tsconfig.lib.json",
-            "packageJson": "libs/rxjs-state/package.json",
-            "main": "libs/rxjs-state/src/index.ts",
-            "assets": ["libs/rxjs-state/*.md"]
           }
         }
       }

--- a/apps/ng-reactive-experiments/src/app/cd-config.service.ts
+++ b/apps/ng-reactive-experiments/src/app/cd-config.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { DEFAULT_STRATEGY_NAME } from '@ngx-rx/ngrx-component-experiments';
-import { RxState } from '@ngx-rx-state';
+import { RxState } from 'ngx-rx-state';
 
 export interface CdConfig {
   strategies: string[];

--- a/apps/ng-reactive-experiments/src/app/config-panel.component.ts
+++ b/apps/ng-reactive-experiments/src/app/config-panel.component.ts
@@ -15,7 +15,7 @@ import { CdConfigService } from './cd-config.service';
 import { FormBuilder } from '@angular/forms';
 import { defer, fromEvent, merge, Observable } from 'rxjs';
 import { startWith, tap } from 'rxjs/operators';
-import { RxState } from '@ngx-rx-state';
+import { RxState } from 'ngx-rx-state';
 
 @Component({
   selector: 'app-config-panel',

--- a/apps/ng-reactive-experiments/src/app/performance/performance-03/index/performance03-index.component.ts
+++ b/apps/ng-reactive-experiments/src/app/performance/performance-03/index/performance03-index.component.ts
@@ -16,7 +16,7 @@ import {
   Person
 } from './performance-03-data.service';
 import { environment } from '../../../../environments/environment';
-import { RxState } from '@ngx-rx-state';
+import { RxState } from 'ngx-rx-state';
 
 export interface Performance03State {
   data: Person[];

--- a/apps/ng-reactive-experiments/src/app/performance/performance-04/index/performance04-index.component.ts
+++ b/apps/ng-reactive-experiments/src/app/performance/performance-04/index/performance04-index.component.ts
@@ -8,7 +8,7 @@ import {
   Person
 } from './performance-04-data.service';
 import { environment } from '../../../../environments/environment';
-import { RxState } from '@ngx-rx-state';
+import { RxState } from 'ngx-rx-state';
 
 export interface Performance04State {
   data: Person[];

--- a/apps/ng-reactive-experiments/src/app/rx-state/01/parent.component.ts
+++ b/apps/ng-reactive-experiments/src/app/rx-state/01/parent.component.ts
@@ -2,7 +2,7 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { environment } from '../../../environments/environment';
 import { EMPTY, of, range, Subject, Subscription } from 'rxjs';
 import { tap } from 'rxjs/operators';
-import { RxState } from '@ngx-rx-state';
+import { RxState } from 'ngx-rx-state';
 import { BaseComponent } from '../../base.component.ts/base.component';
 
 @Component({

--- a/libs/ngrx-component-experiments/tsconfig.spec.json
+++ b/libs/ngrx-component-experiments/tsconfig.spec.json
@@ -3,15 +3,7 @@
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"],
-    "paths": {
-      "@ngx-rx-state": [
-        "libs/ngx-rx-state/src/index.ts"
-      ],
-      "rxjs-state": [
-        "libs/rxjs-state/src/index.ts"
-      ]
-    }
+    "types": ["jest", "node"]
   },
   "files": ["src/test-setup.ts"],
   "include": ["**/*.spec.ts", "**/*.d.ts"]

--- a/libs/ngx-rx-state/tsconfig.lib.json
+++ b/libs/ngx-rx-state/tsconfig.lib.json
@@ -5,13 +5,7 @@
     "declaration": true,
     "inlineSources": true,
     "types": [],
-    "lib": ["dom", "es2018"],
-    "paths": {
-      "rxjs-state": [
-        "dist/libs/rxjs-state",
-        "libs/rxjs-state/src/index.ts"
-      ]
-    }
+    "lib": ["dom", "es2018"]
   },
   "angularCompilerOptions": {
     "enableIvy": false,

--- a/libs/rxjs-state/ng-package.json
+++ b/libs/rxjs-state/ng-package.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
+  "dest": "../../dist/libs/rxjs-state",
+  "lib": {
+    "entryFile": "src/index.ts"
+  }
+}

--- a/libs/rxjs-state/src/lib/index.ts
+++ b/libs/rxjs-state/src/lib/index.ts
@@ -4,4 +4,8 @@ export {
   createAccumulationObservable,
   createSideEffectObservable
 } from './core';
-export { RxJsState } from './state';
+/* @hack importing /index fixes "Maximum call stack size exceeded" error
+ * when building library with ng-packagr.
+ * Cf. https://github.com/ng-packagr/ng-packagr/issues/1093#issuecomment-427570451
+ * Do we really need this indirection? */
+export { RxJsState } from './state/index';

--- a/libs/rxjs-state/tsconfig.lib.json
+++ b/libs/rxjs-state/tsconfig.lib.json
@@ -1,11 +1,16 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "commonjs",
     "outDir": "../../dist/out-tsc",
     "declaration": true,
     "rootDir": "./src",
     "types": ["node"]
+  },
+  "angularCompilerOptions": {
+    "enableIvy": false,
+    "skipTemplateCodegen": true,
+    "strictMetadataEmit": true,
+    "enableResourceInlining": true
   },
   "exclude": ["**/*.spec.ts"],
   "include": ["**/*.ts"]

--- a/libs/rxjs-state/tsconfig.lib.prod.json
+++ b/libs/rxjs-state/tsconfig.lib.prod.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.lib.json",
+  "angularCompilerOptions": {
+    "enableIvy": false
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,10 +30,10 @@
       "@rxjs-etc": [
         "libs/rxjs-etc/src/index.ts"
       ],
-      "@rxjs-state": [
+      "rxjs-state": [
         "libs/rxjs-state/src/index.ts"
       ],
-      "@ngx-rx-state": [
+      "ngx-rx-state": [
         "libs/ngx-rx-state/src/index.ts"
       ],
       "@ngrx-component-experiments": [


### PR DESCRIPTION
This will build `rxjs-state` with **ng-packagr** too _(just like `ngx-rx-state`)_ and produce a library in Angular Package Format. This should fix issues with Jest & Stackblitz.

Other improvement ideas:

1. We could harmonize the monorepo by using `ng-packagr` for all packages.
2. Package names should either start with a scope or not be prefixed with `@`. This means `@rxjs-etc` should be renamed to `rxjs-etc` or `@ngx-rx/rxjs-etc` with a preference for the latest.